### PR TITLE
fix jumping on egui click, extend egui example

### DIFF
--- a/examples/egui.rs
+++ b/examples/egui.rs
@@ -21,6 +21,10 @@ fn egui_setup(mut egui_context: ResMut<EguiContext>) {
         .resizable(false)
         .show(egui_context.ctx_mut(), |ui| {
             ScrollArea::vertical().show(ui, |ui| {
+                ui.add_space(100.);
+                ui.color_edit_button_rgb(&mut [0., 0., 0.]);
+                ui.add(egui::Slider::new(&mut 0.0, 0.0..=1.0).step_by(0.001));
+                ui.checkbox(&mut true, "Test");
                 ui.vertical(|ui| {
                     for i in 0..50 {
                         ui.label(format!("list entry number {i}"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ fn camera_movement(
     #[cfg(feature = "bevy_egui")]
     if let Some(mut egui_ctx) = egui_ctx {
         if egui_ctx.ctx_mut().wants_pointer_input() || egui_ctx.ctx_mut().wants_keyboard_input() {
+            *last_pos = None;
             return;
         }
     }


### PR DESCRIPTION
Fixes jumping which can sometimes occur when clicking and dragging a egui window.

(also makes the egui example more complex)