### PR TITLE
change readme examples to work with bevy 0.8

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ App::build()
 Add the component to an orthographic camera:
 
 ```rust
-commands.spawn_bundle(OrthographicCameraBundle::new_2d())
+commands.spawn_bundle(Camera2dBundle::default())
     .insert(PanCam::default());
 ```
 
@@ -38,7 +38,7 @@ This is enough to get going with sensible defaults.
 Alternatively, set the fields of the `PanCam` component to customize behavior:
 
 ```rust
-commands.spawn_bundle(OrthographicCameraBundle::new_2d())
+commands.spawn_bundle(Camera2dBundle::default())
     .insert(PanCam {
         grab_buttons: vec![MouseButton::Left, MouseButton::Middle], // which buttons should drag the camera
         enabled: true, // when false, controls are disabled. See toggle example.


### PR DESCRIPTION
Bevy 0.8 removed OrthographicCameraBundle and replaced the 2D functionality with Camera2dBundle.

This change updates readme.md examples to work with the latest version of Bevy. 