### PR TITLE
add config options to allow global coord clamping

### DIFF
--- a/examples/clamped_borders.rs
+++ b/examples/clamped_borders.rs
@@ -14,17 +14,19 @@ fn setup(mut commands: Commands) {
     commands
         .spawn_bundle(Camera2dBundle::default())
         .insert(PanCam {
-            // Set max scale in order to prevent the camera from zooming too far out
+            // prevent the camera from zooming too far out
             max_scale: Some(40.),
-            // Set min scale in order to prevent the camera from zooming too far in
+            // prevent the camera from zooming too far in
             min_scale: 0.5,
-            // Set min x boundary to prevent the camera from panning or zooming past it
+            // prevent the camera from panning or zooming past x -750. -750 was chosen to display both the edges of the
+            // sample image and some boundary space beyond it
             min_x: Some(-750.),
-            // Set max x boundary to prevent the camera from panning or zooming past it
+            // prevent the camera from panning or zooming past x 1750. 1750 was chosen to show an asymmetric boundary
+            // window with more space on the right than the left
             max_x: Some(1750.),
-            // Set min y boundary to prevent the camera from panning or zooming past it
+            // prevent the camera from panning or zooming past y -750. value chosen for same reason as above
             min_y: Some(-750.),
-            // Set max y boundary to prevent the camera from panning or zooming past it
+            // prevent the camera from panning or zooming past y 1750. value chosen for same reason as above
             max_y: Some(1750.),
             ..default()
         });

--- a/examples/clamped_borders.rs
+++ b/examples/clamped_borders.rs
@@ -1,0 +1,52 @@
+use bevy::prelude::*;
+use bevy_pancam::{PanCam, PanCamPlugin};
+use rand::prelude::random;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(PanCamPlugin::default())
+        .add_startup_system(setup)
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    commands
+        .spawn_bundle(Camera2dBundle::default())
+        .insert(PanCam {
+            // Set max scale in order to prevent the camera from zooming too far out
+            max_scale: Some(40.),
+            // Set min scale in order to prevent the camera from zooming too far in
+            min_scale: 0.5,
+            // Set min x boundary to prevent the camera from panning or zooming past it
+            min_x: Some(-750.),
+            // Set max x boundary to prevent the camera from panning or zooming past it
+            max_x: Some(1750.),
+            // Set min y boundary to prevent the camera from panning or zooming past it
+            min_y: Some(-750.),
+            // Set max y boundary to prevent the camera from panning or zooming past it
+            max_y: Some(1750.),
+            ..default()
+        });
+
+    let n = 20;
+    let spacing = 50.;
+    let offset = spacing * n as f32 / 2.;
+    let custom_size = Some(Vec2::new(spacing, spacing));
+    for x in 0..n {
+        for y in 0..n {
+            let x = x as f32 * spacing - offset;
+            let y = y as f32 * spacing - offset;
+            let color = Color::hsl(240., random::<f32>() * 0.3, random::<f32>() * 0.3);
+            commands.spawn_bundle(SpriteBundle {
+                sprite: Sprite {
+                    color,
+                    custom_size,
+                    ..default()
+                },
+                transform: Transform::from_xyz(x, y, 0.),
+                ..default()
+            });
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,10 +56,25 @@ fn camera_zoom(
             let old_scale = proj.scale;
             proj.scale = (proj.scale * (1. + -scroll * 0.001)).max(cam.min_scale);
 
+            // Apply max scale constraint
             if let Some(max_scale) = cam.max_scale {
                 proj.scale = proj.scale.min(max_scale);
             }
 
+            // If there is both a min and max x boundary, that limits how far we can zoom. Make sure we don't exceed that
+            if let (Some(min_x_bound), Some(max_x_bound)) = (cam.min_x, cam.max_x) {
+                let max_safe_scale =
+                    max_scale_within_x_bounds(&min_x_bound, &max_x_bound, &window.width(), &proj);
+                proj.scale = proj.scale.min(max_safe_scale);
+            }
+            // If there is both a min and max y boundary, that limits how far we can zoom. Make sure we don't exceed that
+            if let (Some(min_y_bound), Some(max_y_bound)) = (cam.min_y, cam.max_y) {
+                let max_safe_scale =
+                    max_scale_within_y_bounds(&min_y_bound, &max_y_bound, &window.height(), &proj);
+                proj.scale = proj.scale.min(max_safe_scale);
+            }
+
+            // Move the camera position to normalize the projection window
             if let (Some(mouse_normalized_screen_pos), true) =
                 (mouse_normalized_screen_pos, cam.zoom_to_cursor)
             {
@@ -69,9 +84,110 @@ fn camera_zoom(
                 pos.translation = (mouse_world_pos
                     - mouse_normalized_screen_pos * proj_size * proj.scale)
                     .extend(pos.translation.z);
+
+                // As we zoom out, we don't want the viewport to move beyond the provided boundary. If the most recent
+                // change to the camera zoom would move cause parts of the window beyond the boundary to be shown, we
+                // need to change the camera position to keep the viewport within bounds. The four if statements below
+                // provide this behavior for the min and max x and y boundaries.
+                let scaling = Vec2::new(
+                    window.width() / (proj.right - proj.left),
+                    window.height() / (proj.top - proj.bottom),
+                ) * proj.scale;
+                if let Some(min_x_bound) = cam.min_x {
+                    let half_of_viewport = (window.width() / 2.) * scaling.x;
+                    let min_safe_cam_x = min_x_bound + half_of_viewport;
+                    pos.translation.x = pos.translation.x.max(min_safe_cam_x);
+                }
+                if let Some(max_x_bound) = cam.max_x {
+                    let half_of_viewport = (window.width() / 2.) * scaling.x;
+                    let max_safe_cam_x = max_x_bound - half_of_viewport;
+                    pos.translation.x = pos.translation.x.min(max_safe_cam_x);
+                }
+                if let Some(min_y_bound) = cam.min_y {
+                    let half_of_viewport = (window.height() / 2.) * scaling.y;
+                    let min_safe_cam_y = min_y_bound + half_of_viewport;
+                    pos.translation.y = pos.translation.y.max(min_safe_cam_y);
+                }
+                if let Some(max_y_bound) = cam.max_y {
+                    let half_of_viewport = (window.height() / 2.) * scaling.y;
+                    let max_safe_cam_y = max_y_bound - half_of_viewport;
+                    pos.translation.y = pos.translation.y.min(max_safe_cam_y);
+                }
             }
         }
     }
+}
+
+/// max_scale_within_x_bounds is used to find the maximum safe zoom out/projection scale when we have been provided with
+/// minimum and maximum x boundaries for the camera.
+///
+/// The maximum amount that we can zoom in or out is affected by both the default scaling between the
+/// window and the projection, and the clamped scaling enforced by the provided coordinate boundaries.
+/// The examples below aim to explain why we need to account for both, and what happens when we turn the
+/// various knobs
+///
+/// - In the simplest case where the width of the projection and window are both 100, and assuming we
+///   have an image that fills the default window.
+///     default_projection_scale = 1.
+///     - If max_width_between_boundaries = 100
+///         boundary_scale = 1.
+///         max_safe_x_scale = 1. * 1. = 1
+///         (Scrolling out this far shows the whole original image)
+///     - If max_width_between_boundaries = 50
+///         boundary_scale = 0.5
+///         max_safe_x_scale = 1. * 0.5 = 0.5
+///         (Scrolling out this far shows a quarter of the original image)
+///     - If max_width_between_boundaries = 200
+///         boundary_scale = 2.
+///         max_safe_x_scale = 2. * 1. = 2.
+///         (Scrolling out this far shows empty space around the original image)
+///        
+/// - If, instead, we have a square projection 100 wide, and a square window 200 wide, with an image
+///   200 wide filling the original window
+///     default_projection_scale = 0.5
+///     - If max_width_between_boundaries = 200
+///         boundary_scale = 1.
+///         max_safe_x_scale = 0.5 * 1. = 0.5
+///         (Scrolling out this far shows a quarter of the original image)
+///     - If max_width_between_boundaries = 400
+///         boundary_scale = 2.
+///         max_safe_x_scale = 0.5 * 2. = 1.
+///         (Scrolling out this far lets us scroll beyond the original window size, and see the whole image)
+///     - If max_width_between_boundaries = 800
+///         boundary_scale = 3.
+///         max_safe_x_scale = 0.5 * 3. = 1.5
+///         (Scrolling out this far lets us scroll beyond the original image and see empty space on either side)
+fn max_scale_within_x_bounds(
+    min_x_bound: &f32,
+    max_x_bound: &f32,
+    window_width: &f32,
+    proj: &OrthographicProjection,
+) -> f32 {
+    let projection_width = proj.right - proj.left;
+    let default_projection_scale = projection_width / window_width;
+
+    let max_width_between_boundaries = max_x_bound - min_x_bound;
+    let boundary_scale = max_width_between_boundaries / window_width;
+
+    return default_projection_scale * boundary_scale;
+}
+
+/// max_scale_within_y_bounds is used to find the maximum safe zoom out/projection scale when we have been provided with
+/// minimum and maximum y boundaries for the camera. It behaves identically to max_scale_within_x_bounds but uses the
+/// height of the window and projection instead of their width.
+fn max_scale_within_y_bounds(
+    min_y_bound: &f32,
+    max_y_bound: &f32,
+    window_height: &f32,
+    proj: &OrthographicProjection,
+) -> f32 {
+    let projection_height = proj.top - proj.bottom;
+    let default_projection_scale = projection_height / window_height;
+
+    let max_height_between_boundaries = max_y_bound - min_y_bound;
+    let boundary_scale = max_height_between_boundaries / window_height;
+
+    return default_projection_scale * boundary_scale;
 }
 
 fn camera_movement(
@@ -110,7 +226,29 @@ fn camera_movement(
                 window.height() / (projection.top - projection.bottom),
             ) * projection.scale;
 
-            transform.translation -= (delta * scaling).extend(0.);
+            // The proposed new camera position
+            let mut proposed_cam_transform = transform.translation - (delta * scaling).extend(0.);
+
+            // Check whether the proposed camera movement would be within the provided boundaries, override it if we
+            // need to do so to stay within bounds.
+            if let Some(min_x_boundary) = cam.min_x {
+                let min_safe_cam_x = min_x_boundary + ((window.width() / 2.) * scaling.x);
+                proposed_cam_transform.x = proposed_cam_transform.x.max(min_safe_cam_x);
+            }
+            if let Some(max_x_boundary) = cam.max_x {
+                let max_safe_cam_x = max_x_boundary - ((window.width() / 2.) * scaling.x);
+                proposed_cam_transform.x = proposed_cam_transform.x.min(max_safe_cam_x);
+            }
+            if let Some(min_y_boundary) = cam.min_y {
+                let min_safe_cam_y = min_y_boundary + ((window.height() / 2.) * scaling.y);
+                proposed_cam_transform.y = proposed_cam_transform.y.max(min_safe_cam_y);
+            }
+            if let Some(max_y_boundary) = cam.max_y {
+                let max_safe_cam_y = max_y_boundary - ((window.height() / 2.) * scaling.y);
+                proposed_cam_transform.y = proposed_cam_transform.y.min(max_safe_cam_y);
+            }
+
+            transform.translation = proposed_cam_transform;
         }
     }
     *last_pos = Some(current_pos);
@@ -142,6 +280,26 @@ pub struct PanCam {
     /// If present, the orthographic projection's scale will be clamped at
     /// this value when zooming out.
     pub max_scale: Option<f32>,
+    /// The minimum x position of the camera window
+    ///
+    /// If present, the orthographic projection will be clamped to this boundary both
+    /// when dragging the window, and zooming out.
+    pub min_x: Option<f32>,
+    /// The maximum x position of the camera window
+    ///
+    /// If present, the orthographic projection will be clamped to this boundary both
+    /// when dragging the window, and zooming out.
+    pub max_x: Option<f32>,
+    /// The minimum y position of the camera window
+    ///
+    /// If present, the orthographic projection will be clamped to this boundary both
+    /// when dragging the window, and zooming out.
+    pub min_y: Option<f32>,
+    /// The maximum y position of the camera window
+    ///
+    /// If present, the orthographic projection will be clamped to this boundary both
+    /// when dragging the window, and zooming out.
+    pub max_y: Option<f32>,
 }
 
 impl Default for PanCam {
@@ -152,6 +310,10 @@ impl Default for PanCam {
             zoom_to_cursor: true,
             min_scale: 0.00001,
             max_scale: None,
+            min_x: None,
+            max_x: None,
+            min_y: None,
+            max_y: None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,3 +297,66 @@ impl Plugin for InspectablePlugin {
         inspectable_registry.register::<PanCam>();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use bevy::prelude::OrthographicProjection;
+
+    use super::*;
+
+    // Simple mock function to construct a square projection window and run it, plus some square boundaries, through
+    // the provided scale func
+    fn mock_scale_func(
+        proj_size: f32,
+        bound_width: f32,
+        scale_func: &dyn Fn(f32, f32, &OrthographicProjection) -> f32,
+    ) -> f32 {
+        let proj = OrthographicProjection {
+            left: -(proj_size / 2.),
+            bottom: -(proj_size / 2.),
+            right: (proj_size / 2.),
+            top: (proj_size / 2.),
+            ..Default::default()
+        };
+        let min_bound = -(bound_width / 2.);
+        let max_bound = bound_width / 2.;
+
+        return scale_func(min_bound, max_bound, &proj);
+    }
+
+    // projection and bounds are equal-width, both have symmetric edges. Expect max scale of 1.0
+    #[test]
+    fn test_max_scale_x_01() {
+        assert_eq!(mock_scale_func(100., 100., &max_scale_within_x_bounds), 1.);
+    }
+
+    // boundaries are 1/2 the size of the projection window, expects max scale of 0.5
+    #[test]
+    fn test_max_scale_x_02() {
+        assert_eq!(mock_scale_func(100., 50., &max_scale_within_x_bounds), 0.5);
+    }
+
+    // boundaries are 2x the size of the projection window, expects max scale of 2.0
+    #[test]
+    fn test_max_scale_x_03() {
+        assert_eq!(mock_scale_func(100., 200., &max_scale_within_x_bounds), 2.);
+    }
+
+    // projection and bounds are equal-height, expects max scale of 1.0
+    #[test]
+    fn test_max_scale_y_01() {
+        assert_eq!(mock_scale_func(100., 100., &max_scale_within_y_bounds), 1.);
+    }
+
+    // boundaries are 1/2 the size of the projection window, expects max scale of 0.5
+    #[test]
+    fn test_max_scale_y_02() {
+        assert_eq!(mock_scale_func(100., 50., &max_scale_within_y_bounds), 0.5);
+    }
+
+    // boundaries are 2x the size of the projection window, expects max scale of 2.0
+    #[test]
+    fn test_max_scale_y_03() {
+        assert_eq!(mock_scale_func(100., 200., &max_scale_within_y_bounds), 2.);
+    }
+}


### PR DESCRIPTION
- allows one to set a minimum and maximum x and y to act as boundaries for the camera projection
- works for both dragging and zooming

Fixes: #11 