### PR TITLE
Fix bugs with fixed scaling modes

### DIFF
--- a/examples/camera_scaling_mode.rs
+++ b/examples/camera_scaling_mode.rs
@@ -1,0 +1,39 @@
+use bevy::{prelude::*, render::camera::ScalingMode};
+use bevy_pancam::{PanCam, PanCamPlugin};
+use rand::prelude::random;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(PanCamPlugin::default())
+        .add_startup_system(setup)
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    let mut cam = Camera2dBundle::default();
+    cam.projection.scaling_mode = ScalingMode::FixedVertical(10.0);
+
+    commands.spawn_bundle(cam).insert(PanCam::default());
+
+    let n = 20;
+    let spacing = 1.;
+    let offset = spacing * n as f32 / 2.;
+    let custom_size = Some(Vec2::new(1.0, 1.0));
+    for x in 0..n {
+        for y in 0..n {
+            let x = x as f32 * spacing - offset;
+            let y = y as f32 * spacing - offset;
+            let color = Color::hsl(240., random::<f32>() * 0.3, random::<f32>() * 0.3);
+            commands.spawn_bundle(SpriteBundle {
+                sprite: Sprite {
+                    color,
+                    custom_size,
+                    ..default()
+                },
+                transform: Transform::from_xyz(x, y, 0.),
+                ..default()
+            });
+        }
+    }
+}

--- a/examples/camera_scaling_mode.rs
+++ b/examples/camera_scaling_mode.rs
@@ -14,16 +14,22 @@ fn setup(mut commands: Commands) {
     let mut cam = Camera2dBundle::default();
     cam.projection.scaling_mode = ScalingMode::FixedVertical(10.0);
 
-    commands.spawn_bundle(cam).insert(PanCam::default());
+    commands.spawn_bundle(cam).insert(PanCam {
+        min_x: Some(-10.),
+        max_x: Some(10.),
+        min_y: Some(-10.),
+        max_y: Some(10.0),
+        ..default()
+    });
 
     let n = 20;
     let spacing = 1.;
-    let offset = spacing * n as f32 / 2.;
+    let offset = -spacing * n as f32 / 2. + spacing / 2.;
     let custom_size = Some(Vec2::new(1.0, 1.0));
     for x in 0..n {
         for y in 0..n {
-            let x = x as f32 * spacing - offset;
-            let y = y as f32 * spacing - offset;
+            let x = x as f32 * spacing + offset;
+            let y = y as f32 * spacing + offset;
             let color = Color::hsl(240., random::<f32>() * 0.3, random::<f32>() * 0.3);
             commands.spawn_bundle(SpriteBundle {
                 sprite: Sprite {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,6 +179,7 @@ fn camera_movement(
     }
 
     let window = windows.get_primary().unwrap();
+    let window_size = Vec2::new(window.width(), window.height());
 
     // Use position instead of MouseMotion, otherwise we don't get acceleration movement
     let current_pos = match window.cursor_position() {
@@ -194,10 +195,12 @@ fn camera_movement(
                 .iter()
                 .any(|btn| mouse_buttons.pressed(*btn))
         {
-            let world_units_per_device_pixel = Vec2::new(
-                (projection.right - projection.left) / window.width(),
-                (projection.top - projection.bottom) / window.height(),
+            let proj_size = Vec2::new(
+                projection.right - projection.left,
+                projection.top - projection.bottom,
             ) * projection.scale;
+
+            let world_units_per_device_pixel = proj_size / window_size;
 
             // The proposed new camera position
             let delta_world = delta_device_pixels * world_units_per_device_pixel;
@@ -207,22 +210,22 @@ fn camera_movement(
             // need to do so to stay within bounds.
             if let Some(min_x_boundary) = cam.min_x {
                 let min_safe_cam_x =
-                    min_x_boundary + ((window.width() / 2.) * world_units_per_device_pixel.x);
+                    min_x_boundary + window_size.x / 2. * world_units_per_device_pixel.x;
                 proposed_cam_transform.x = proposed_cam_transform.x.max(min_safe_cam_x);
             }
             if let Some(max_x_boundary) = cam.max_x {
                 let max_safe_cam_x =
-                    max_x_boundary - ((window.width() / 2.) * world_units_per_device_pixel.x);
+                    max_x_boundary - window_size.x / 2. * world_units_per_device_pixel.x;
                 proposed_cam_transform.x = proposed_cam_transform.x.min(max_safe_cam_x);
             }
             if let Some(min_y_boundary) = cam.min_y {
                 let min_safe_cam_y =
-                    min_y_boundary + ((window.height() / 2.) * world_units_per_device_pixel.y);
+                    min_y_boundary + window_size.y / 2. * world_units_per_device_pixel.y;
                 proposed_cam_transform.y = proposed_cam_transform.y.max(min_safe_cam_y);
             }
             if let Some(max_y_boundary) = cam.max_y {
                 let max_safe_cam_y =
-                    max_y_boundary - ((window.height() / 2.) * world_units_per_device_pixel.y);
+                    max_y_boundary - window_size.y / 2. * world_units_per_device_pixel.y;
                 proposed_cam_transform.y = proposed_cam_transform.y.min(max_safe_cam_y);
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -337,7 +337,7 @@ mod tests {
         let min_bound = -(bound_width / 2.);
         let max_bound = bound_width / 2.;
 
-        return scale_func(min_bound, max_bound, &proj);
+        scale_func(min_bound, max_bound, &proj)
     }
 
     // projection and bounds are equal-width, both have symmetric edges. Expect max scale of 1.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,7 @@ mod tests {
             bottom: -(proj_size / 2.),
             right: (proj_size / 2.),
             top: (proj_size / 2.),
-            ..Default::default()
+            ..default()
         };
         let min_bound = -(bound_width / 2.);
         let max_bound = bound_width / 2.;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,28 +95,25 @@ fn camera_zoom(
                 // change to the camera zoom would move cause parts of the window beyond the boundary to be shown, we
                 // need to change the camera position to keep the viewport within bounds. The four if statements below
                 // provide this behavior for the min and max x and y boundaries.
-                let scaling = Vec2::new(
-                    window.width() / (proj.right - proj.left),
-                    window.height() / (proj.top - proj.bottom),
-                ) * proj.scale;
+                let proj_size =
+                    Vec2::new(proj.right - proj.left, proj.top - proj.bottom) * proj.scale;
+
+                let half_of_viewport = proj_size / 2.;
+
                 if let Some(min_x_bound) = cam.min_x {
-                    let half_of_viewport = (window.width() / 2.) * scaling.x;
-                    let min_safe_cam_x = min_x_bound + half_of_viewport;
+                    let min_safe_cam_x = min_x_bound + half_of_viewport.x;
                     pos.translation.x = pos.translation.x.max(min_safe_cam_x);
                 }
                 if let Some(max_x_bound) = cam.max_x {
-                    let half_of_viewport = (window.width() / 2.) * scaling.x;
-                    let max_safe_cam_x = max_x_bound - half_of_viewport;
+                    let max_safe_cam_x = max_x_bound - half_of_viewport.x;
                     pos.translation.x = pos.translation.x.min(max_safe_cam_x);
                 }
                 if let Some(min_y_bound) = cam.min_y {
-                    let half_of_viewport = (window.height() / 2.) * scaling.y;
-                    let min_safe_cam_y = min_y_bound + half_of_viewport;
+                    let min_safe_cam_y = min_y_bound + half_of_viewport.y;
                     pos.translation.y = pos.translation.y.max(min_safe_cam_y);
                 }
                 if let Some(max_y_bound) = cam.max_y {
-                    let half_of_viewport = (window.height() / 2.) * scaling.y;
-                    let max_safe_cam_y = max_y_bound - half_of_viewport;
+                    let max_safe_cam_y = max_y_bound - half_of_viewport.y;
                     pos.translation.y = pos.translation.y.min(max_safe_cam_y);
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,23 +206,19 @@ fn camera_movement(
             // Check whether the proposed camera movement would be within the provided boundaries, override it if we
             // need to do so to stay within bounds.
             if let Some(min_x_boundary) = cam.min_x {
-                let min_safe_cam_x =
-                    min_x_boundary + window_size.x / 2. * world_units_per_device_pixel.x;
+                let min_safe_cam_x = min_x_boundary + proj_size.x / 2.;
                 proposed_cam_transform.x = proposed_cam_transform.x.max(min_safe_cam_x);
             }
             if let Some(max_x_boundary) = cam.max_x {
-                let max_safe_cam_x =
-                    max_x_boundary - window_size.x / 2. * world_units_per_device_pixel.x;
+                let max_safe_cam_x = max_x_boundary - proj_size.x / 2.;
                 proposed_cam_transform.x = proposed_cam_transform.x.min(max_safe_cam_x);
             }
             if let Some(min_y_boundary) = cam.min_y {
-                let min_safe_cam_y =
-                    min_y_boundary + window_size.y / 2. * world_units_per_device_pixel.y;
+                let min_safe_cam_y = min_y_boundary + proj_size.y / 2.;
                 proposed_cam_transform.y = proposed_cam_transform.y.max(min_safe_cam_y);
             }
             if let Some(max_y_boundary) = cam.max_y {
-                let max_safe_cam_y =
-                    max_y_boundary - window_size.y / 2. * world_units_per_device_pixel.y;
+                let max_safe_cam_y = max_y_boundary - proj_size.y / 2.;
                 proposed_cam_transform.y = proposed_cam_transform.y.min(max_safe_cam_y);
             }
 


### PR DESCRIPTION
Setting `OrthographicProjection::scaling_mode` to `FixedVertical` or `FixedHorizontal` would result in the camera moving the wrong number of pixels.

This should fix it for those modes. Rotated orthographic modes are still not supported.