### PR TITLE
Update to bevy-inspector-egui 0.15 and bevy_egui 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,10 @@ version = "0.7.0"
 
 [features]
 bevy_egui = ["dep:bevy_egui"]
-bevy-inspector-egui = ["dep:bevy-inspector-egui"]
 
 [dependencies]
 bevy = {version = "0.9", features = ["render"], default-features = false}
 bevy_egui = {version = "0.17", optional = true, default-features = false}
-bevy-inspector-egui = { version = "0.15.0-pre.0", optional = true, default-features = false }
 
 [dev-dependencies]
 bevy = {version = "0.9", default-features = false, features = [
@@ -33,7 +31,3 @@ bevy-inspector-egui = {version = "0.15.0-pre.0", default-features = false}
 [[example]]
 name = "egui"
 required-features = ["bevy_egui"]
-
-[[example]]
-name = "inspector"
-required-features = ["bevy-inspector-egui"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ bevy_egui = ["dep:bevy_egui"]
 
 [dependencies]
 bevy = {version = "0.9", features = ["render"], default-features = false}
-bevy_egui = {version = "0.17", optional = true, default-features = false}
+bevy_egui = {version = "0.18", optional = true, default-features = false}
 
 [dev-dependencies]
 bevy = {version = "0.9", default-features = false, features = [
@@ -25,8 +25,8 @@ bevy = {version = "0.9", default-features = false, features = [
   "x11", # github actions runners don't have libxkbcommon installed, so can't use wayland
 ]}
 rand = "0.8"
-bevy_egui = {version = "0.17", default-features = false, features = ["default_fonts"]}
-bevy-inspector-egui = {version = "0.15.0-pre.0", default-features = false}
+bevy_egui = {version = "0.18", default-features = false, features = ["default_fonts"]}
+bevy-inspector-egui = {version = "0.15", default-features = false}
 
 [[example]]
 name = "egui"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ bevy-inspector-egui = ["dep:bevy-inspector-egui"]
 [dependencies]
 bevy = {version = "0.9", features = ["render"], default-features = false}
 bevy_egui = {version = "0.17", optional = true, default-features = false}
-bevy-inspector-egui = { version = "0.14", optional = true, default-features = false }
+bevy-inspector-egui = { version = "0.15.0-pre.0", optional = true, default-features = false }
 
 [dev-dependencies]
 bevy = {version = "0.9", default-features = false, features = [
@@ -28,7 +28,7 @@ bevy = {version = "0.9", default-features = false, features = [
 ]}
 rand = "0.8"
 bevy_egui = {version = "0.17", default-features = false, features = ["default_fonts"]}
-bevy-inspector-egui = {version = "0.14", default-features = false}
+bevy-inspector-egui = {version = "0.15.0-pre.0", default-features = false}
 
 [[example]]
 name = "egui"

--- a/examples/inspector.rs
+++ b/examples/inspector.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_inspector_egui::{widgets::InspectorQuery, InspectorPlugin};
+use bevy_inspector_egui::quick::WorldInspectorPlugin;
 use bevy_pancam::{PanCam, PanCamPlugin};
 use rand::random;
 
@@ -7,7 +7,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(PanCamPlugin::default())
-        .add_plugin(InspectorPlugin::<InspectorQuery<&'static mut PanCam>>::new())
+        .add_plugin(WorldInspectorPlugin)
         .add_startup_system(setup)
         .run();
 }

--- a/examples/inspector.rs
+++ b/examples/inspector.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use bevy_inspector_egui::quick::WorldInspectorPlugin;
+use bevy_inspector_egui::WorldInspectorPlugin;
 use bevy_pancam::{PanCam, PanCamPlugin};
 use rand::random;
 
@@ -7,7 +7,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(PanCamPlugin::default())
-        .add_plugin(WorldInspectorPlugin)
+        .add_plugin(WorldInspectorPlugin::default())
         .add_startup_system(setup)
         .run();
 }

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,6 @@ See the [`simple`](./examples/simple.rs) and [`toggle`](./examples/toggle.rs) ex
 ## Cargo features
 
 - `bevy_egui` makes pancam cameras not react when the mouse or keyboard focus is on widgets created with [`bevy_egui`](https://github.com/mvlabat/bevy_egui)
-- `bevy-inspector-egui` makes pancam cameras be inspectable by [`bevy-inspector-egui`](https://github.com/jakobhellermann/bevy-inspector-egui)
 
 ## Bevy Version Support
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,7 @@ impl Plugin for PanCamPlugin {
         app.add_system(camera_movement.label(PanCamSystemLabel))
             .add_system(camera_zoom.label(PanCamSystemLabel));
 
-        #[cfg(feature = "bevy-inspector-egui")]
-        app.add_plugin(InspectablePlugin);
+        app.register_type::<PanCam>();
     }
 }
 
@@ -286,16 +285,6 @@ impl Default for PanCam {
             min_y: None,
             max_y: None,
         }
-    }
-}
-
-#[cfg(feature = "bevy-inspector-egui")]
-struct InspectablePlugin;
-
-#[cfg(feature = "bevy-inspector-egui")]
-impl Plugin for InspectablePlugin {
-    fn build(&self, app: &mut App) {
-        app.register_type::<PanCam>();
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,10 +226,6 @@ fn camera_movement(
 
 /// A component that adds panning camera controls to an orthographic camera
 #[derive(Component, Reflect)]
-#[cfg_attr(
-    feature = "bevy-inspector-egui",
-    derive(bevy_inspector_egui::InspectorOptions)
-)]
 #[reflect(Component)]
 pub struct PanCam {
     /// The mouse buttons that will be used to drag and pan the camera

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,6 @@ use bevy::{
     render::camera::OrthographicProjection,
 };
 
-#[cfg(feature = "bevy-inspector-egui")]
-use bevy_inspector_egui::InspectableRegistry;
-
 /// Plugin that adds the necessary systems for `PanCam` components to work
 #[derive(Default)]
 pub struct PanCamPlugin;
@@ -229,14 +226,14 @@ fn camera_movement(
 }
 
 /// A component that adds panning camera controls to an orthographic camera
-#[derive(Component)]
+#[derive(Component, Reflect)]
 #[cfg_attr(
     feature = "bevy-inspector-egui",
-    derive(bevy_inspector_egui::Inspectable)
+    derive(bevy_inspector_egui::InspectorOptions)
 )]
+#[reflect(Component)]
 pub struct PanCam {
     /// The mouse buttons that will be used to drag and pan the camera
-    #[cfg_attr(feature = "bevy-inspector-egui", inspectable(ignore))]
     pub grab_buttons: Vec<MouseButton>,
     /// Whether camera currently responds to user input
     pub enabled: bool,
@@ -293,17 +290,12 @@ impl Default for PanCam {
 }
 
 #[cfg(feature = "bevy-inspector-egui")]
-#[derive(bevy_inspector_egui::Inspectable)]
 struct InspectablePlugin;
 
 #[cfg(feature = "bevy-inspector-egui")]
 impl Plugin for InspectablePlugin {
     fn build(&self, app: &mut App) {
-        let mut inspectable_registry = app
-            .world
-            .get_resource_or_insert_with(InspectableRegistry::default);
-
-        inspectable_registry.register::<PanCam>();
+        app.register_type::<PanCam>();
     }
 }
 


### PR DESCRIPTION
- [x] bump to non-pre version of bevy-inspector-egui
- [ ] find replacement for `InspectorQuery`?