### PR TITLE
Fix clamping on zoom out

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,10 +237,10 @@ fn camera_movement(
 
     for (cam, mut transform, projection) in &mut query {
         if cam.enabled
-            && (cam
+            && cam
                 .grab_buttons
                 .iter()
-                .any(|btn| mouse_buttons.pressed(*btn)))
+                .any(|btn| mouse_buttons.pressed(*btn))
         {
             clamp_translation(
                 cam,
@@ -313,7 +313,6 @@ impl Default for PanCam {
         }
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,50 @@ fn check_egui_wants_focus(
     wants_focus.set_if_neq(EguiWantsFocus(new_wants_focus));
 }
 
+fn clamp_translation(
+    cam: &PanCam,
+    projection: &OrthographicProjection,
+    transform: &mut Transform,
+    delta_device_pixels: Vec2,
+    window_size: Vec2,
+) {
+    let proj_size = projection.area.size();
+
+    let world_units_per_device_pixel = proj_size / window_size;
+
+    // The proposed new camera position
+    let delta_world = delta_device_pixels * world_units_per_device_pixel;
+    let mut proposed_cam_transform = transform.translation - delta_world.extend(0.);
+
+    // Check whether the proposed camera movement would be within the provided boundaries, override it if we
+    // need to do so to stay within bounds.
+    if let Some(min_x_boundary) = cam.min_x {
+        let min_safe_cam_x = min_x_boundary + proj_size.x / 2.;
+        proposed_cam_transform.x = proposed_cam_transform.x.max(min_safe_cam_x);
+    }
+    if let Some(max_x_boundary) = cam.max_x {
+        let max_safe_cam_x = max_x_boundary - proj_size.x / 2.;
+        proposed_cam_transform.x = proposed_cam_transform.x.min(max_safe_cam_x);
+    }
+    if let Some(min_y_boundary) = cam.min_y {
+        let min_safe_cam_y = min_y_boundary + proj_size.y / 2.;
+        proposed_cam_transform.y = proposed_cam_transform.y.max(min_safe_cam_y);
+    }
+    if let Some(max_y_boundary) = cam.max_y {
+        let max_safe_cam_y = max_y_boundary - proj_size.y / 2.;
+        proposed_cam_transform.y = proposed_cam_transform.y.min(max_safe_cam_y);
+    }
+
+    transform.translation = proposed_cam_transform;
+}
+
 fn camera_zoom(
-    mut query: Query<(&PanCam, &mut OrthographicProjection, &mut Transform)>,
+    mut query: Query<(
+        &PanCam,
+        &mut OrthographicProjection,
+        &mut Transform,
+        &mut Camera,
+    )>,
     mut scroll_events: EventReader<MouseWheel>,
     primary_window: Query<&Window, With<PrimaryWindow>>,
 ) {
@@ -75,7 +117,7 @@ fn camera_zoom(
         .cursor_position()
         .map(|cursor_pos| (cursor_pos / window_size) * 2. - Vec2::ONE);
 
-    for (cam, mut proj, mut pos) in &mut query {
+    for (cam, mut proj, mut pos, camera) in &mut query {
         if cam.enabled {
             let old_scale = proj.scale;
             proj.scale = (proj.scale * (1. + -scroll * 0.001)).max(cam.min_scale);
@@ -152,6 +194,12 @@ fn camera_zoom(
                     pos.translation.y = pos.translation.y.min(max_safe_cam_y);
                 }
             }
+
+            if let Some(size) = camera.logical_viewport_size() {
+                proj.update(size.x, size.y);
+            }
+
+            clamp_translation(cam, &mut proj, &mut pos, Vec2::default(), window_size);
         }
     }
 }
@@ -189,39 +237,18 @@ fn camera_movement(
 
     for (cam, mut transform, projection) in &mut query {
         if cam.enabled
-            && cam
+            && (cam
                 .grab_buttons
                 .iter()
-                .any(|btn| mouse_buttons.pressed(*btn))
+                .any(|btn| mouse_buttons.pressed(*btn)))
         {
-            let proj_size = projection.area.size();
-
-            let world_units_per_device_pixel = proj_size / window_size;
-
-            // The proposed new camera position
-            let delta_world = delta_device_pixels * world_units_per_device_pixel;
-            let mut proposed_cam_transform = transform.translation - delta_world.extend(0.);
-
-            // Check whether the proposed camera movement would be within the provided boundaries, override it if we
-            // need to do so to stay within bounds.
-            if let Some(min_x_boundary) = cam.min_x {
-                let min_safe_cam_x = min_x_boundary + proj_size.x / 2.;
-                proposed_cam_transform.x = proposed_cam_transform.x.max(min_safe_cam_x);
-            }
-            if let Some(max_x_boundary) = cam.max_x {
-                let max_safe_cam_x = max_x_boundary - proj_size.x / 2.;
-                proposed_cam_transform.x = proposed_cam_transform.x.min(max_safe_cam_x);
-            }
-            if let Some(min_y_boundary) = cam.min_y {
-                let min_safe_cam_y = min_y_boundary + proj_size.y / 2.;
-                proposed_cam_transform.y = proposed_cam_transform.y.max(min_safe_cam_y);
-            }
-            if let Some(max_y_boundary) = cam.max_y {
-                let max_safe_cam_y = max_y_boundary - proj_size.y / 2.;
-                proposed_cam_transform.y = proposed_cam_transform.y.min(max_safe_cam_y);
-            }
-
-            transform.translation = proposed_cam_transform;
+            clamp_translation(
+                cam,
+                projection,
+                &mut transform,
+                delta_device_pixels,
+                window_size,
+            );
         }
     }
     *last_pos = Some(current_pos);
@@ -286,6 +313,7 @@ impl Default for PanCam {
         }
     }
 }
+
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Hello! 👋  Thank you for your plugin. I discovered a bug in it when trying to adopt it and have a proposed fix. I'm very new to Rust/Bevy, so my proposed solution is probably bad and wrong, but hopefully it's at least clear enough to highlight the issue and motivate a proper solution.

Consider the following scenario:

- bevy_pancam plugin is instantiated and configured with min/max clamping
- user zooms in
- user pans to the top
- user zooms out

In this scenario, clamping is not applied when the user zooms out and the clamp bounds are not respected. Then, when the user next clicks, the clamping value is enforced.

Here is a video of this issue reproducing on my system: https://www.loom.com/share/1f963e13433248019f46bfc598528a00

This occurs because the `camera_movement` system enforces clamping, but it no-ops if no mouse buttons are pressed. Since the user has zoomed out by scrolling the mouse wheel - no mouse buttons are pressed and thus no clamping occurs.

Initially, I tried to fix this by modifying `camera_movement`. My initial solution was to change `query` to utilize `Ref<OrthographicProjection>` and to loosen the no-op conditional to ` || projection.is_changed()`. This solution does work, but introduces a one frame lag which visualizes as slight flickering in the UI.

I did not find this flickering to be an acceptable solution. So, I continued to explore. I then decided that the core of the `camera_movement` logic should run immediately from the `camera_zoom` system. I added this code, but found it to no-op because `projection.area.size()` was not returning an updated value.

So, I dug into Bevy's camera code a bit and copied a snippet from their internal `camera_system` system:

```
        if let Some(normalized_target) = camera.target.normalize(primary_window) {
            if normalized_target.is_changed(&changed_window_ids, &changed_image_handles)
                || camera.is_added()
                || camera_projection.is_changed()
                || camera.computed.old_viewport_size != viewport_size
            {
                camera.computed.target_info =
                    normalized_target.get_render_target_info(&windows, &images);
                if let Some(size) = camera.logical_viewport_size() {
                    camera_projection.update(size.x, size.y);
                    camera.computed.projection_matrix = camera_projection.get_projection_matrix();
                }
            }
        }
```

Note that `camera.computed.projection_matrix` is private so I'm not able to update it. I do not know if omitting this has unintended side-effects, but I do not believe that to be true because `camera_projection.update` is public and so I assume calling `update` is supported.

After calling `camera.update`, and then immediately running the core `camera_movement` clamping logic, the bug no longer reproduced.

Here is a video of the issue not reproducing after applying the fix proposed in this PR: https://www.loom.com/share/c9ced63b910c469d85276eedc92f2f0a



