### PR TITLE
Added keyboard movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Behaves similarly to common online map applications:
 
 - Click and drag to move the camera
 - Scroll to zoom
+- Keep Keyboard buttons pushed to move the camera
 
 ## Usage
 
@@ -41,6 +42,13 @@ Alternatively, set the fields of the `PanCam` component to customize behavior:
 commands.spawn(Camera2dBundle::default())
     .insert(PanCam {
         grab_buttons: vec![MouseButton::Left, MouseButton::Middle], // which buttons should drag the camera
+        move_keys: DirectionKeys {      // the keyboard buttons used to move the camera
+            up:    vec![KeyCode::KeyQ], // initalize the struct like this or use the provided methods for
+            down:  vec![KeyCode::KeyW], // common key combinations
+            left:  vec![KeyCode::KeyE],
+            right: vec![KeyCode::KeyR],
+        },
+        speed: 400., // the speed for the keyboard movement
         enabled: true, // when false, controls are disabled. See toggle example.
         zoom_to_cursor: true, // whether to zoom towards the mouse or the center of the screen
         min_scale: 1., // prevent the camera from zooming too far in

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,10 +24,14 @@ pub struct PanCamSystemSet;
 /// Which keys move the camera in particular directions for keyboard movement.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Reflect)]
 pub struct DirectionKeys {
-    up: Vec<KeyCode>,
-    down: Vec<KeyCode>,
-    left: Vec<KeyCode>,
-    right: Vec<KeyCode>,
+    ///  The keys that move the camera up.
+    pub up: Vec<KeyCode>,
+    ///  The keys that move the camera down.
+    pub down: Vec<KeyCode>,
+    ///  The keys that move the camera left.
+    pub left: Vec<KeyCode>,
+    ///  The keys that move the camera right.
+    pub right: Vec<KeyCode>,
 }
 
 impl Plugin for PanCamPlugin {


### PR DESCRIPTION
Simply added constant keyboard movement to the `do_camera_movement` system and `MoveMode` and `DirectionKeys` fields to `PanCam` and registered them in Bevy.

As I do not know if this change is even desired, this seemed to be the least intrusive API/code change.
Further changes I thought about but discarded because of reason above:
- Option for accelerated movement.
- Splitting the `do_camera_movement` into multiple systems.
- Simultaneous mouse and keyboard `MoveMode`.

Addresses #52 