### PR TITLE
Update bevy_egui

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ bevy_egui = ["dep:bevy_egui"]
 
 [dependencies]
 bevy = {version = "0.14", features = ["bevy_render"], default-features = false}
-bevy_egui = {version = "0.28", optional = true, default-features = false}
+bevy_egui = {version = "0.29", optional = true, default-features = false}
 
 [dev-dependencies]
 bevy = {version = "0.14", default-features = false, features = [
@@ -25,8 +25,8 @@ bevy = {version = "0.14", default-features = false, features = [
   "bevy_core_pipeline",
   "x11", # github actions runners don't have libxkbcommon installed, so can't use wayland
 ]}
-bevy-inspector-egui = { version = "0.25", default-features = false, features = ["bevy_render"]}
-bevy_egui = {version = "0.28", default-features = false, features = ["default_fonts"]}
+bevy-inspector-egui = { version = "0.26", default-features = false, features = ["bevy_render"]}
+bevy_egui = {version = "0.29", default-features = false, features = ["default_fonts"]}
 rand = "0.8"
 
 [[example]]


### PR DESCRIPTION
Tiny chore, updating the bevy_egui version, otherwise the bevy_egui feature breaks.