### PR TITLE
Use `Time<Real>` instead of `Time`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,7 @@ fn do_camera_movement(
     keyboard_buttons: Res<ButtonInput<KeyCode>>,
     mut query: Query<(&PanCam, &Camera, &mut Transform, &OrthographicProjection)>,
     mut last_pos: Local<Option<Vec2>>,
-    time: Res<Time>,
+    time: Res<Time<Real>>,
 ) {
     let Ok(window) = primary_window.get_single() else {
         return;


### PR DESCRIPTION
Just a suggestion really, curious what u guys think. In my current project I use `Time<Virtual>` extensively and when paused, `PanCam` stops working, because `Time` just follows `Time<Virtual>` AFAIU. My suggestion would be using `Time<Real>` instead.