### PR TITLE
Add a way for the developer to directly ask bevy_pancam to clamp bounds.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ bevy = {version = "0.15", default-features = false, features = [
   "bevy_sprite",
   "bevy_winit",
   "bevy_core_pipeline",
+  "bevy_ui",
   "x11", # github actions runners don't have libxkbcommon installed, so can't use wayland
 ]}
 bevy-inspector-egui = { version = "0.28", default-features = false, features = ["bevy_render"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ bevy = {version = "0.15", default-features = false, features = [
   "bevy_winit",
   "bevy_core_pipeline",
   "bevy_ui",
+  "default_font",
+  "bevy_text",
   "x11", # github actions runners don't have libxkbcommon installed, so can't use wayland
 ]}
 bevy-inspector-egui = { version = "0.28", default-features = false, features = ["bevy_render"] }

--- a/examples/multiple_viewports.rs
+++ b/examples/multiple_viewports.rs
@@ -1,0 +1,130 @@
+use bevy::{
+    prelude::*,
+    render::camera::{ScalingMode, Viewport},
+    window::WindowResized,
+};
+use bevy_pancam::{PanCam, PanCamForceUpdateEvent, PanCamPlugin};
+use rand::prelude::random;
+
+#[derive(Component)]
+#[require(Camera2d)]
+struct LeftCamera;
+
+#[derive(Component)]
+#[require(Camera2d)]
+struct RightCamera;
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, PanCamPlugin))
+        .add_systems(Startup, setup)
+        .add_systems(Update, reset_viewports)
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    // left camera is fixed, draws some simple GUI.
+    let panel_camera = commands.spawn((
+        LeftCamera,
+        Camera {
+            order: 0,
+            ..default()
+        },
+        Transform::from_xyz(-10000., -10000., 0.),
+    )).id();
+    commands.spawn((
+        TargetCamera(panel_camera),
+        Node {
+            width: Val::Percent(100.),
+            height: Val::Percent(100.),
+            ..default()
+        },
+    )).with_children(|parent| {
+        // just for now, let's fill the whole panel with a background color.
+        // TODO: add some, like, explainer text in here to say some things to try out.
+        parent.spawn((
+            Node {
+                width: Val::Percent(100.),
+                height: Val::Percent(100.),
+                ..default()
+            },
+            BackgroundColor(Color::srgb(0.4, 0.2, 0.7)),
+        ));
+    });
+
+    commands.spawn((
+        RightCamera,
+        Camera {
+            order: 1,
+            ..default()
+        },
+        // constrain the bounds to EXACTLY the world area that holds the demo sprites
+        PanCam {
+            min_x: -525.,
+            max_x: 475.,
+            min_y: -525.,
+            max_y: 475.,
+            ..default()
+        },
+        // use AutoMax scaling on the projection itself. this MAY only be needed to work around #73.
+        OrthographicProjection {
+            scaling_mode: ScalingMode::AutoMax {
+                max_width: 1000.,
+                max_height: 1000.,
+            },
+            ..OrthographicProjection::default_2d()
+        },
+    ));
+
+    let n = 20;
+    let spacing = 50.;
+    let offset = spacing * n as f32 / 2.;
+    let custom_size = Some(Vec2::new(spacing, spacing));
+    for x in 0..n {
+        for y in 0..n {
+            let x = x as f32 * spacing - offset;
+            let y = y as f32 * spacing - offset;
+            let color = Color::hsl(240., random::<f32>() * 0.3, random::<f32>() * 0.3);
+            commands.spawn((
+                Sprite {
+                    color,
+                    custom_size,
+                    ..default()
+                },
+                Transform::from_xyz(x, y, 0.),
+            ));
+        }
+    }
+}
+
+
+fn reset_viewports(
+    windows: Query<&Window>,
+    mut resize_events: EventReader<WindowResized>,
+    mut left_camera: Query<&mut Camera, (With<LeftCamera>, Without<RightCamera>)>,
+    mut right_camera: Query<&mut Camera, (Without<LeftCamera>, With<RightCamera>)>,
+    mut force_update: EventWriter<PanCamForceUpdateEvent>,
+) {
+    let mut l = left_camera.single_mut();
+    let mut r = right_camera.single_mut();
+    for resize_event in resize_events.read() {
+        let window = windows.get(resize_event.window).unwrap();
+        let size = window.physical_size();
+
+        let sep = (size.x + 4) / 5;
+        l.viewport = Some(Viewport {
+            physical_size: UVec2 { x: sep, y: size.y },
+            ..default()
+        });
+
+        r.viewport = Some(Viewport {
+            physical_position: UVec2 { x: sep, y: 0 },
+            physical_size: UVec2 { x: size.x - sep, y: size.y },
+            ..default()
+        });
+
+        // for this kind of thing to work properly, bevy_pancam needs to know to recalculate its
+        // bounds / zoom clamping: resizing the window might have moved the camera out of bounds.
+        force_update.send(PanCamForceUpdateEvent);
+    }
+}

--- a/examples/multiple_viewports.rs
+++ b/examples/multiple_viewports.rs
@@ -27,14 +27,16 @@ fn main() {
 
 fn setup(mut commands: Commands) {
     // left camera is fixed, draws some simple GUI.
-    let left_panel_camera = commands.spawn((
-        LeftCamera,
-        Camera {
-            order: 0,
-            ..default()
-        },
-        Transform::from_xyz(-10000., -10000., 0.),
-    )).id();
+    let left_panel_camera = commands
+        .spawn((
+            LeftCamera,
+            Camera {
+                order: 0,
+                ..default()
+            },
+            Transform::from_xyz(-10000., -10000., 0.),
+        ))
+        .id();
     commands.spawn((
         LeftPanel,
         TargetCamera(left_panel_camera),
@@ -112,7 +114,10 @@ fn reset_viewports(
 
         r.viewport = Some(Viewport {
             physical_position: UVec2 { x: sep, y: 0 },
-            physical_size: UVec2 { x: size.x - sep, y: size.y },
+            physical_size: UVec2 {
+                x: size.x - sep,
+                y: size.y,
+            },
             ..default()
         });
 

--- a/examples/multiple_viewports.rs
+++ b/examples/multiple_viewports.rs
@@ -38,22 +38,13 @@ fn setup(mut commands: Commands) {
     commands.spawn((
         LeftPanel,
         TargetCamera(left_panel_camera),
-        Interaction::default(),
         Node {
             width: Val::Percent(100.),
             height: Val::Percent(100.),
             ..default()
         },
-    )).with_children(|parent| {
-        parent.spawn((
-            Node {
-                width: Val::Percent(100.),
-                height: Val::Percent(100.),
-                ..default()
-            },
-            Text::new("In this example, the pattern of squares on the right will always fill 80% of the window, keeping its aspect ratio, even as the window resizes."),
-        ));
-    });
+        Text::new("In this example, the pattern of squares on the right will always fill 80% of the window, keeping its aspect ratio, even as the window resizes."),
+    ));
 
     commands.spawn((
         RightCamera,

--- a/examples/multiple_viewports.rs
+++ b/examples/multiple_viewports.rs
@@ -3,7 +3,7 @@ use bevy::{
     render::camera::{ScalingMode, Viewport},
     window::WindowResized,
 };
-use bevy_pancam::{PanCam, PanCamForceUpdateEvent, PanCamPlugin};
+use bevy_pancam::{PanCam, PanCamHintClampBoundsEvent, PanCamPlugin};
 use rand::prelude::random;
 
 #[derive(Component)]
@@ -103,7 +103,7 @@ fn reset_viewports(
     mut resize_events: EventReader<WindowResized>,
     mut left_camera: Query<&mut Camera, (With<LeftCamera>, Without<RightCamera>)>,
     mut right_camera: Query<&mut Camera, (Without<LeftCamera>, With<RightCamera>)>,
-    mut force_update: EventWriter<PanCamForceUpdateEvent>,
+    mut force_update: EventWriter<PanCamHintClampBoundsEvent>,
 ) {
     let mut l = left_camera.single_mut();
     let mut r = right_camera.single_mut();
@@ -125,6 +125,6 @@ fn reset_viewports(
 
         // for this kind of thing to work properly, bevy_pancam needs to know to recalculate its
         // bounds / zoom clamping: resizing the window might have moved the camera out of bounds.
-        force_update.send(PanCamForceUpdateEvent);
+        force_update.send(PanCamHintClampBoundsEvent);
     }
 }

--- a/examples/multiple_viewports.rs
+++ b/examples/multiple_viewports.rs
@@ -3,7 +3,7 @@ use bevy::{
     render::camera::{ScalingMode, Viewport},
     window::WindowResized,
 };
-use bevy_pancam::{PanCam, PanCamHintClampBoundsEvent, PanCamPlugin};
+use bevy_pancam::{PanCam, PanCamClampBounds, PanCamPlugin};
 use rand::prelude::random;
 
 #[derive(Component)]
@@ -97,11 +97,11 @@ fn reset_viewports(
     windows: Query<&Window>,
     mut resize_events: EventReader<WindowResized>,
     mut left_camera: Query<&mut Camera, (With<LeftCamera>, Without<RightCamera>)>,
-    mut right_camera: Query<&mut Camera, (Without<LeftCamera>, With<RightCamera>)>,
-    mut force_update: EventWriter<PanCamHintClampBoundsEvent>,
+    mut right_camera: Query<(Entity, &mut Camera), (Without<LeftCamera>, With<RightCamera>)>,
+    mut commands: Commands,
 ) {
     let mut l = left_camera.single_mut();
-    let mut r = right_camera.single_mut();
+    let (r_entity, mut r) = right_camera.single_mut();
     for resize_event in resize_events.read() {
         let window = windows.get(resize_event.window).unwrap();
         let size = window.physical_size();
@@ -121,8 +121,8 @@ fn reset_viewports(
             ..default()
         });
 
-        // for this kind of thing to work properly, bevy_pancam needs to know to recalculate its
-        // bounds / zoom clamping: resizing the window might have moved the camera out of bounds.
-        force_update.send(PanCamHintClampBoundsEvent);
+        // for this kind of thing to work properly, we must manually trigger bevy_pancam to clamp
+        // the bounds, since it only does this automatically when it's the one to move them.
+        commands.trigger_targets(PanCamClampBounds, r_entity);
     }
 }

--- a/examples/multiple_viewports.rs
+++ b/examples/multiple_viewports.rs
@@ -11,6 +11,9 @@ use rand::prelude::random;
 struct LeftCamera;
 
 #[derive(Component)]
+struct LeftPanel;
+
+#[derive(Component)]
 #[require(Camera2d)]
 struct RightCamera;
 
@@ -24,7 +27,7 @@ fn main() {
 
 fn setup(mut commands: Commands) {
     // left camera is fixed, draws some simple GUI.
-    let panel_camera = commands.spawn((
+    let left_panel_camera = commands.spawn((
         LeftCamera,
         Camera {
             order: 0,
@@ -33,22 +36,22 @@ fn setup(mut commands: Commands) {
         Transform::from_xyz(-10000., -10000., 0.),
     )).id();
     commands.spawn((
-        TargetCamera(panel_camera),
+        LeftPanel,
+        TargetCamera(left_panel_camera),
+        Interaction::default(),
         Node {
             width: Val::Percent(100.),
             height: Val::Percent(100.),
             ..default()
         },
     )).with_children(|parent| {
-        // just for now, let's fill the whole panel with a background color.
-        // TODO: add some, like, explainer text in here to say some things to try out.
         parent.spawn((
             Node {
                 width: Val::Percent(100.),
                 height: Val::Percent(100.),
                 ..default()
             },
-            BackgroundColor(Color::srgb(0.4, 0.2, 0.7)),
+            Text::new("In this example, the pattern of squares on the right will always fill 80% of the window, keeping its aspect ratio, even as the window resizes."),
         ));
     });
 
@@ -96,7 +99,6 @@ fn setup(mut commands: Commands) {
         }
     }
 }
-
 
 fn reset_viewports(
     windows: Query<&Window>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,13 +21,10 @@ pub struct PanCamPlugin;
 #[derive(Debug, Clone, Copy, SystemSet, PartialEq, Eq, Hash)]
 pub struct PanCamSystemSet;
 
-/// Event that requests the camera to update without a mouse or keyboard event triggering it.
-///
-/// Intended for situations where PanCam is configured with limits on zoom and/or bounds, and those
-/// limits (or the projection itself) have just been changed by an external source that might have
-/// caused the current viewport to start violating them.
+/// Event raised when an external trigger (i.e., something other than the player's input) might have
+/// invalidated the configured limits on camera bounds.
 #[derive(Event)]
-pub struct PanCamForceUpdateEvent;
+pub struct PanCamHintClampBoundsEvent;
 
 /// Which keys move the camera in particular directions for keyboard movement
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Reflect)]
@@ -110,10 +107,10 @@ impl Plugin for PanCamPlugin {
             Update,
             (
                 (do_camera_movement, do_camera_zoom),
-                do_clamp_bounds.run_if(on_event::<PanCamForceUpdateEvent>),
+                do_clamp_bounds.run_if(on_event::<PanCamHintClampBoundsEvent>),
             ).chain().in_set(PanCamSystemSet),
         )
-        .add_event::<PanCamForceUpdateEvent>()
+        .add_event::<PanCamHintClampBoundsEvent>()
         .register_type::<PanCam>()
         .register_type::<DirectionKeys>();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,9 @@ impl Plugin for PanCamPlugin {
             (
                 (do_camera_movement, do_camera_zoom),
                 do_clamp_bounds.run_if(on_event::<PanCamHintClampBoundsEvent>),
-            ).chain().in_set(PanCamSystemSet),
+            )
+                .chain()
+                .in_set(PanCamSystemSet),
         )
         .add_event::<PanCamHintClampBoundsEvent>()
         .register_type::<PanCam>()
@@ -336,9 +338,7 @@ fn do_camera_movement(
     *last_pos = Some(current_pos);
 }
 
-fn do_clamp_bounds(
-    mut query: Query<(&PanCam, &mut Transform, &OrthographicProjection)>,
-) {
+fn do_clamp_bounds(mut query: Query<(&PanCam, &mut Transform, &OrthographicProjection)>) {
     for (pan_cam, mut transform, projection) in &mut query {
         if !pan_cam.enabled {
             continue;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub struct PanCamPlugin;
 #[derive(Debug, Clone, Copy, SystemSet, PartialEq, Eq, Hash)]
 pub struct PanCamSystemSet;
 
-/// Triggered when the camera should clamp its bounds
+/// Trigger this event after changing the camera bounds potentially outside the safe zone.
 #[derive(Event)]
 pub struct PanCamClampBounds;
 


### PR DESCRIPTION
Bounds clamping on `PanCam` seems incomplete, or at least a bit inconsistent with itself. It **feels** like it assumes that this plugin is the only thing that affects the camera's bounds, but it's not very hard to come up with a situation where this is not the case.

I doubt that it's right to **always** try to clamp bounds at every `Update`, and it's probably overkill to have `do_camera_movement` / `do_camera_zoom` run to completion just to get them to do `clamp_to_safe_zone`. So what I've done instead is a bit of a compromise: any time a different system makes a change that might push the bounds outside of the limits that they configured in PanCam, that system is also expected to fire a `PanCamHintClampBoundsEvent`. Ideally, they should do this **before** `PanCamSystemSet`.

As a side note, I've only **JUST** gotten started using bevy (and I have no other experience with any other game engine), so if I've done something stupid or confusing, that's probably why.

I've included a new example to show (a version of) how I encountered the issue, and how this new event solves it. In case my machine is the weird one, here's what it looks like with vs. without the new event:

https://github.com/user-attachments/assets/e8ac15fd-0b65-4f0a-8ea4-710e89681282