### PR TITLE
Support `PinchGesture` events for zoom in/out

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,10 @@
 #![doc = include_str!("../README.md")]
 
 use bevy::{
-    input::mouse::{MouseScrollUnit, MouseWheel},
+    input::{
+        gestures::PinchGesture,
+        mouse::{MouseScrollUnit, MouseWheel},
+    },
     math::{
         Rect,
         bounding::{Aabb2d, BoundingVolume},
@@ -145,12 +148,16 @@ fn check_egui_wants_focus(
 
 fn do_camera_zoom(
     mut query: Query<(&PanCam, &Camera, &mut Projection, &mut Transform)>,
+    mut pinch_events: EventReader<PinchGesture>,
     scroll_events: EventReader<MouseWheel>,
     primary_window: Query<&Window, With<PrimaryWindow>>,
 ) {
+    const PINCH_MULTIPLIER: f32 = 1000.;
     const ZOOM_SENSITIVITY: f32 = 0.001;
 
-    let scroll_offset = scroll_offset_from_events(scroll_events);
+    let pinch_scroll_offset = pinch_events.read().map(|ev| ev.0).sum::<f32>() * PINCH_MULTIPLIER;
+    let wheel_scroll_offset = scroll_offset_from_events(scroll_events);
+    let scroll_offset = pinch_scroll_offset + wheel_scroll_offset;
     if scroll_offset == 0. {
         return;
     }

--- a/src/normalized_zoom_inputs.rs
+++ b/src/normalized_zoom_inputs.rs
@@ -1,0 +1,51 @@
+use bevy::input::{
+    gestures::PinchGesture,
+    mouse::{MouseScrollUnit, MouseWheel},
+};
+use bevy::prelude::*;
+
+/// Holds normalized zoom inputs constructed from
+/// raw events.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct NormalizedZoomInputs {
+    pub pinch: f32,
+    pub wheel: f32,
+}
+
+impl NormalizedZoomInputs {
+    /// Reads [`MouseWheel`] and [`PinchGesture`] [`EventReader`]s, normalizes
+    /// them, and returns a new [`NormalizedZoomInputs`].
+    pub(crate) fn from_events(
+        mut mouse_wheel_events: EventReader<MouseWheel>,
+        mut pinch_gesture_events: EventReader<PinchGesture>,
+    ) -> Self {
+        let pinch = pinch_gesture_events.read().map(|ev| ev.0).sum::<f32>();
+
+        // Wheel event deltas are roughly 1000 larger scale than equivalent
+        // pinchs and way too large to apply as-is, so we normalize them by
+        // dividing by 1000.
+        const MOUSE_WHEEL_NORMALIZE_FACTOR: f32 = 0.001;
+        const PIXELS_PER_LINE: f32 = 100.; // Maybe make configurable?
+        let wheel = mouse_wheel_events
+            .read()
+            .map(|ev| match ev.unit {
+                MouseScrollUnit::Pixel => ev.y,
+                MouseScrollUnit::Line => ev.y * PIXELS_PER_LINE,
+            })
+            .sum::<f32>()
+            * MOUSE_WHEEL_NORMALIZE_FACTOR;
+
+        Self { pinch, wheel }
+    }
+
+    /// Apply sensitivity scalers to the inputs and return a final zoom delta
+    /// to apply.
+    pub(crate) fn apply_sensitivity(&self, wheel_sensitivity: f32, pinch_sensitivity: f32) -> f32 {
+        self.pinch * pinch_sensitivity + self.wheel * wheel_sensitivity
+    }
+
+    /// True when no input.
+    pub(crate) fn is_empty(self) -> bool {
+        self.pinch == 0. && self.wheel == 0.
+    }
+}


### PR DESCRIPTION
Adds support for zooming in/out on MacOS and iOS using the pinch gesture.

I tried also supporting `PanGesture` for movement, but wasn't able to get the events to trigger with my Macbook 🤷🏼‍♂️

https://github.com/user-attachments/assets/c4142044-81ec-481f-9532-1503657942a4